### PR TITLE
Feature/add map to any of

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # fluent-comparisons
 ![build](https://github.com/geo-ant/fluent-comparisons/workflows/build/badge.svg?branch=main)
-![tests](https://github.com/geo-ant/fluent-comparisons/workflows/tests/badge.svg?branch=main)
 ![lints](https://github.com/geo-ant/fluent-comparisons/workflows/lints/badge.svg?branch=main)
+![tests](https://github.com/geo-ant/fluent-comparisons/workflows/tests/badge.svg?branch=main)
+![approval-tests](https://github.com/geo-ant/fluent-comparisons/workflows/approval-tests/badge.svg?branch=main)
 
 **Fluent syntax for multi-comparisons.**
 

--- a/fluent-comparisons-macros/src/lib.rs
+++ b/fluent-comparisons-macros/src/lib.rs
@@ -54,11 +54,7 @@ macro_rules! __check_operator {
 macro_rules! any_of {
     //TODO: DOCUMENT THIS VARIANT WITH MAP (WITHOUT RHS)
     ( {$($lh_sides:expr),+}.satisfies($($func:tt)+) ) => {
-        {
-            //$crate::__check_operator!($operator);
-            let map_func = $($func)+;
-            $( map_func($lh_sides) )||+
-        }
+        any_of!({$($lh_sides),+}.map($($func)+)==true)
     };
 
     //TODO: DOCUMENT THIS VARIANT WITH MAP (WITH RHS)

--- a/fluent-comparisons-macros/src/lib.rs
+++ b/fluent-comparisons-macros/src/lib.rs
@@ -53,7 +53,7 @@ macro_rules! __check_operator {
 #[macro_export]
 macro_rules! any_of {
     //TODO: DOCUMENT THIS VARIANT WITH MAP (WITHOUT RHS)
-    ( {$($lh_sides:expr),+}.satisfies($($func:tt)+) ) => {
+    ( {$($lh_sides:expr),+}.satisfy($($func:tt)+) ) => {
         any_of!({$($lh_sides),+}.map($($func)+)==true)
     };
 
@@ -62,7 +62,7 @@ macro_rules! any_of {
         {
             $crate::__check_operator!($operator);
             let map_func = $($func)+;
-            $( map_func($lh_sides) $operator $rhs)||+
+            $( (map_func($lh_sides) $operator $rhs) )||+
         }
     };
 

--- a/fluent-comparisons-macros/src/lib.rs
+++ b/fluent-comparisons-macros/src/lib.rs
@@ -52,6 +52,25 @@ macro_rules! __check_operator {
 /// ```
 #[macro_export]
 macro_rules! any_of {
+    //TODO: DOCUMENT THIS VARIANT WITH MAP (WITHOUT RHS)
+    ( {$($lh_sides:expr),+}.satisfies($($func:tt)+) ) => {
+        {
+            //$crate::__check_operator!($operator);
+            let map_func = $($func)+;
+            $( map_func($lh_sides) )||+
+        }
+    };
+
+    //TODO: DOCUMENT THIS VARIANT WITH MAP (WITH RHS)
+    ( {$($lh_sides:expr),+}.map($($func:tt)+) $operator:tt $rhs:expr) => {
+        {
+            $crate::__check_operator!($operator);
+            let map_func = $($func)+;
+            $( map_func($lh_sides) $operator $rhs)||+
+        }
+    };
+
+    //variant without map (requires a comparison operator and rhs)
     ( {$($lh_sides:expr),+} $operator:tt $rhs:expr)=> {
         {
             $crate::__check_operator!($operator);

--- a/macro_expansion_tests/any_of_with_map_or_satisfies_expansion.expanded.rs
+++ b/macro_expansion_tests/any_of_with_map_or_satisfies_expansion.expanded.rs
@@ -1,0 +1,39 @@
+use fluent_comparisons::any_of;
+struct Dummy {
+    pub length: usize,
+}
+#[automatically_derived]
+#[allow(unused_qualifications)]
+impl ::core::marker::Copy for Dummy {}
+#[automatically_derived]
+#[allow(unused_qualifications)]
+impl ::core::clone::Clone for Dummy {
+    #[inline]
+    fn clone(&self) -> Dummy {
+        {
+            let _: ::core::clone::AssertParamIsClone<usize>;
+            *self
+        }
+    }
+}
+pub fn something() {
+    let cond1 = {
+        let map_func = |x| x * x;
+        (map_func(1) < 4) || (map_func(2) < 4) || (map_func(3) < 4)
+    };
+    let is_even = |x| x % 2 == 0;
+    let cond2 = {
+        let map_func = is_even;
+        (map_func(1) == true) || (map_func(2) == true) || (map_func(3) == true)
+    };
+    let d1 = Dummy { length: 2 };
+    let d2 = Dummy { length: 3 };
+    let cond3 = {
+        let map_func = |d| d.length * 2;
+        (map_func(d1) == d1.length) || (map_func(d2) == d1.length)
+    };
+    let cond4 = {
+        let map_func = |d| d.length == 2;
+        (map_func(d1) == true) || (map_func(d2) == true)
+    };
+}

--- a/macro_expansion_tests/any_of_with_map_or_satisfies_expansion.rs
+++ b/macro_expansion_tests/any_of_with_map_or_satisfies_expansion.rs
@@ -1,0 +1,17 @@
+use fluent_comparisons::any_of;
+#[derive(Copy,Clone)]
+struct Dummy {
+    pub length : usize,
+}
+
+pub fn something() {
+    let cond1 = any_of!({1,2,3}.map(|x|x*x)<4);
+    let is_even = |x|x%2==0;
+    let cond2 = any_of!({1,2,3}.satisfy(is_even));
+
+
+    let d1 = Dummy {length : 2};
+    let d2 = Dummy {length : 3};
+    let cond3 = any_of!( {d1,d2}.map(|d|d.length*2) == d1.length);
+    let cond4 = any_of!( {d1,d2}.satisfy(|d|d.length==2));
+}

--- a/src/tests/any_of.rs
+++ b/src/tests/any_of.rs
@@ -96,7 +96,7 @@ fn expressions_are_short_circuited_and_evaluated_left_to_right() {
 fn test_random_collection_of_values_behave_correctly() {
     let mut rng = thread_rng();
 
-    for _ in 1..1000000 {
+    for _ in 1..100000 {
         let a = rng.gen_range(-5..5);
         let b = rng.gen_range(-5..5);
         let c = rng.gen_range(-5..5);

--- a/src/tests/any_of_with_map.rs
+++ b/src/tests/any_of_with_map.rs
@@ -1,0 +1,36 @@
+#![allow(clippy::int_plus_one)]
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::assertions_on_constants)]
+
+use crate::any_of;
+
+#[test]
+fn any_of_comparisons_give_correct_result_for_operator_equal() {
+    // test very simple expressions with 2 elements
+    assert_eq!(any_of!({3,4,5}.satisfies(|x|x%2==0)), true);
+    assert_eq!(any_of!({3,4,5}.map(|x|x%2)==0), true);
+    assert_eq!(any_of!({ 4 }.map(|x|x*x) == 4), true);
+    assert_eq!(any_of!({ 2 } == 4), false);
+    assert_eq!(any_of!( {4,2} == 4), true);
+    assert_eq!(any_of!( {2,4} == 4), true);
+    assert_eq!(any_of!( {4,4} == 4), true);
+    assert_eq!(any_of!( {4,2} == 1), false);
+    assert_eq!(any_of!( {2,4} == 1), false);
+
+    // test more complicated expressions with 3 elements
+    //assert_eq!()
+
+    let v = vec![1, 2];
+    assert_eq!(
+        any_of!( {2f64.cos(),3f64.sin(),0f64.cos()} <= -std::f64::EPSILON),
+        true
+    );
+    assert_eq!(any_of!( {v.len(),2_usize.pow(2),3*4+1} == v.len()), true);
+    assert_eq!(any_of!( {3_usize.pow(2),333,1+1} == v.len()), true);
+    assert_eq!(any_of!( {v.len(),2,1+1} == v.len()), true);
+    assert_eq!(any_of!( {v.len(),2,1} == v.len().pow(1)), true);
+    assert_eq!(
+        any_of!( {v.len()/2,v.len()-1,v.len().pow(4)} == v.len()),
+        false
+    );
+}

--- a/src/tests/any_of_with_map.rs
+++ b/src/tests/any_of_with_map.rs
@@ -3,34 +3,103 @@
 #![allow(clippy::assertions_on_constants)]
 
 use crate::any_of;
+use rand::prelude::*;
+
+#[macro_use]
+use super::helper::*;
 
 #[test]
-fn any_of_comparisons_give_correct_result_for_operator_equal() {
-    // test very simple expressions with 2 elements
+fn any_of_with_map_comparisons_give_correct_result_for_operator_equal() {
+    // test very simple expressions
     assert_eq!(any_of!({3,4,5}.satisfy(|x|x%2==0)), true);
     assert_eq!(any_of!({3,4,5}.map(|x|x%2)==0), true);
-    assert_eq!(any_of!({ 4 }.map(|x|x*x) == 4), true);
-    assert_eq!(any_of!({ 2 } == 4), false);
-    assert_eq!(any_of!( {4,2} == 4), true);
-    assert_eq!(any_of!( {2,4} == 4), true);
-    assert_eq!(any_of!( {4,4} == 4), true);
-    assert_eq!(any_of!( {4,2} == 1), false);
-    assert_eq!(any_of!( {2,4} == 1), false);
+    assert_eq!(any_of!({ 2 }.map(|x|x*x) == 4), true);
+    assert_eq!(any_of!({ 2,4 }.map(|x:i32|x.pow(10)) == 4), false);
 
-    // test more complicated expressions with 3 elements
-    //assert_eq!()
+    // test more complicated expressions
 
     let v = vec![1, 2];
     assert_eq!(
         any_of!( {2f64.cos(),3f64.sin(),0f64.cos()} <= -std::f64::EPSILON),
         true
     );
-    assert_eq!(any_of!( {v.len(),2_usize.pow(2),3*4+1} == v.len()), true);
-    assert_eq!(any_of!( {3_usize.pow(2),333,1+1} == v.len()), true);
-    assert_eq!(any_of!( {v.len(),2,1+1} == v.len()), true);
-    assert_eq!(any_of!( {v.len(),2,1} == v.len().pow(1)), true);
+    assert_eq!(any_of!( {v.len(),2_usize.pow(2),3*4+1}.map(|x:usize|-(x as i64)) == -(v.len() as i64)), true);
     assert_eq!(
-        any_of!( {v.len()/2,v.len()-1,v.len().pow(4)} == v.len()),
+        any_of!( {v.len()/2,v.len()-1,v.len().pow(4)}.satisfy(|x|x==v.len())),
         false
     );
+}
+
+#[test]
+// the macro should not care about which comparison operator I plug in, but I want
+// to make sure it works, nonetheless
+fn test_any_of_comparisons_for_other_comparison_operators() {
+    let square = |x| x * x;
+    // !=
+    assert_eq!(any_of!({2,2,2,2}.map(|x|x-1)!=2), true);
+    assert_eq!(any_of!({2,1+1}.map(square)!=4), false);
+    // <=
+    assert_eq!(any_of!({square(3),8,120,1}.satisfy(|x|x<=8)), true);
+    assert_eq!(any_of!({4+4+1,square(7*2),120_i32.pow(2)}.map(|x|x-1)<=8), true);
+    // >=
+    assert_eq!(any_of!({-11,3}.satisfy(|x|x>=2)), true);
+    assert_eq!(any_of!({40,50}.map(|x|x/10)>=10), false);
+    // <
+    assert_eq!(any_of!({14,20,120,30}.map(|x|x/2)<8), true);
+    assert_eq!(any_of!({4+1,square(2),2_i32.pow(2)}.map(|x|x+5)<8), false);
+    // >
+    assert_eq!(any_of!({-11,3}.satisfy(|x|x>-10)), true);
+    assert_eq!(any_of!({-11,5}.map(|x|x-1)>4), false);
+}
+
+#[test]
+// use some randomness for asserting theories that should always be true. So I just calculate
+// the expected result of the all of expression and then compare it to a known result that I
+// calculate using standard library iterators.
+// Inspired by the "Beautiful Testing" chapter in the book "Beautiful Code", O'Reilly
+// https://www.oreilly.com/library/view/beautiful-code/9780596510046/
+fn test_random_collection_of_values_behave_correctly() {
+    let mut rng = thread_rng();
+
+    for _ in 1..100000 {
+        let a = rng.gen_range(-5..5);
+        let b = rng.gen_range(-5..5);
+        let c = rng.gen_range(-5..5);
+        let d = rng.gen_range(-5..5);
+        let rhs = rng.gen_range(-5..5);
+
+        // check that the output truly maps and is the same as the iter based solution
+        // also check that the satisfy(...) with an equivalent predicate works
+        assert_all_eq!(any_of!({a,b,c,d}.map(|x|x*2) == rhs),
+            any_of!({a,b,c,d}.satisfy(|x|x*2==rhs)),
+            [a, b, c, d].iter().map(|x|x*2).any(|v| v == rhs)
+        );
+
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x+1)<=rhs),
+            any_of!({a,b,c,d}.satisfy(|x|x+1<=rhs)),
+            [a, b, c, d].iter().map(|x| x + 1).any(|v| v <= rhs)
+        );
+
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x-1)>=rhs),
+            any_of!({a,b,c,d}.satisfy(|x|x-1>=rhs)),
+            [a, b, c, d].iter().map(|x| x - 1).any(|v| v >= rhs)
+        );
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x+1)>rhs),
+            any_of!({a,b,c,d}.satisfy(|x|x+1>rhs)),
+            [a, b, c, d].iter().map(|x|x+1).any(|v| v > rhs)
+        );
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x+1)<rhs),
+            any_of!({a,b,c,d}.satisfy(|x|x+1<rhs)),
+            [a, b, c, d].iter().map(|x|x+1).any(|v| v < rhs)
+        );
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x+1)!=rhs+1),
+            any_of!({a,b,c,d}.satisfy(|x|x+1!=rhs+1)),
+            [a, b, c, d].iter().map(|x|x+1).any(|v| v != rhs+1)
+        );
+    }
 }

--- a/src/tests/any_of_with_map.rs
+++ b/src/tests/any_of_with_map.rs
@@ -13,7 +13,7 @@ fn any_of_with_map_comparisons_give_correct_result_for_operator_equal() {
     // test very simple expressions
     assert_eq!(any_of!({3,4,5}.satisfy(|x|x%2==0)), true);
     assert_eq!(any_of!({3,4,5}.map(|x|x%2)==0), true);
-    assert_eq!(any_of!({ 2 }.map(|x|x*x) == 4), true);
+    assert_eq!(any_of!({ 2 }.map(|x| x * x) == 4), true);
     assert_eq!(any_of!({ 2,4 }.map(|x:i32|x.pow(10)) == 4), false);
 
     // test more complicated expressions
@@ -23,7 +23,10 @@ fn any_of_with_map_comparisons_give_correct_result_for_operator_equal() {
         any_of!( {2f64.cos(),3f64.sin(),0f64.cos()} <= -std::f64::EPSILON),
         true
     );
-    assert_eq!(any_of!( {v.len(),2_usize.pow(2),3*4+1}.map(|x:usize|-(x as i64)) == -(v.len() as i64)), true);
+    assert_eq!(
+        any_of!( {v.len(),2_usize.pow(2),3*4+1}.map(|x:usize|-(x as i64)) == -(v.len() as i64)),
+        true
+    );
     assert_eq!(
         any_of!( {v.len()/2,v.len()-1,v.len().pow(4)}.satisfy(|x|x==v.len())),
         false
@@ -40,7 +43,10 @@ fn test_any_of_comparisons_for_other_comparison_operators() {
     assert_eq!(any_of!({2,1+1}.map(square)!=4), false);
     // <=
     assert_eq!(any_of!({square(3),8,120,1}.satisfy(|x|x<=8)), true);
-    assert_eq!(any_of!({4+4+1,square(7*2),120_i32.pow(2)}.map(|x|x-1)<=8), true);
+    assert_eq!(
+        any_of!({4+4+1,square(7*2),120_i32.pow(2)}.map(|x|x-1)<=8),
+        true
+    );
     // >=
     assert_eq!(any_of!({-11,3}.satisfy(|x|x>=2)), true);
     assert_eq!(any_of!({40,50}.map(|x|x/10)>=10), false);
@@ -70,9 +76,10 @@ fn test_random_collection_of_values_behave_correctly() {
 
         // check that the output truly maps and is the same as the iter based solution
         // also check that the satisfy(...) with an equivalent predicate works
-        assert_all_eq!(any_of!({a,b,c,d}.map(|x|x*2) == rhs),
+        assert_all_eq!(
+            any_of!({a,b,c,d}.map(|x|x*2) == rhs),
             any_of!({a,b,c,d}.satisfy(|x|x*2==rhs)),
-            [a, b, c, d].iter().map(|x|x*2).any(|v| v == rhs)
+            [a, b, c, d].iter().map(|x| x * 2).any(|v| v == rhs)
         );
 
         assert_all_eq!(
@@ -89,17 +96,17 @@ fn test_random_collection_of_values_behave_correctly() {
         assert_all_eq!(
             any_of!({a,b,c,d}.map(|x|x+1)>rhs),
             any_of!({a,b,c,d}.satisfy(|x|x+1>rhs)),
-            [a, b, c, d].iter().map(|x|x+1).any(|v| v > rhs)
+            [a, b, c, d].iter().map(|x| x + 1).any(|v| v > rhs)
         );
         assert_all_eq!(
             any_of!({a,b,c,d}.map(|x|x+1)<rhs),
             any_of!({a,b,c,d}.satisfy(|x|x+1<rhs)),
-            [a, b, c, d].iter().map(|x|x+1).any(|v| v < rhs)
+            [a, b, c, d].iter().map(|x| x + 1).any(|v| v < rhs)
         );
         assert_all_eq!(
             any_of!({a,b,c,d}.map(|x|x+1)!=rhs+1),
             any_of!({a,b,c,d}.satisfy(|x|x+1!=rhs+1)),
-            [a, b, c, d].iter().map(|x|x+1).any(|v| v != rhs+1)
+            [a, b, c, d].iter().map(|x| x + 1).any(|v| v != rhs + 1)
         );
     }
 }

--- a/src/tests/any_of_with_map.rs
+++ b/src/tests/any_of_with_map.rs
@@ -7,7 +7,7 @@ use crate::any_of;
 #[test]
 fn any_of_comparisons_give_correct_result_for_operator_equal() {
     // test very simple expressions with 2 elements
-    assert_eq!(any_of!({3,4,5}.satisfies(|x|x%2==0)), true);
+    assert_eq!(any_of!({3,4,5}.satisfy(|x|x%2==0)), true);
     assert_eq!(any_of!({3,4,5}.map(|x|x%2)==0), true);
     assert_eq!(any_of!({ 4 }.map(|x|x*x) == 4), true);
     assert_eq!(any_of!({ 2 } == 4), false);

--- a/src/tests/any_of_with_map.rs
+++ b/src/tests/any_of_with_map.rs
@@ -5,9 +5,6 @@
 use crate::any_of;
 use rand::prelude::*;
 
-#[macro_use]
-use super::helper::*;
-
 #[test]
 fn any_of_with_map_comparisons_give_correct_result_for_operator_equal() {
     // test very simple expressions

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -18,19 +18,19 @@ macro_rules! assert_all_eq {
 
 #[test]
 fn test_assert_all_eq_success_cases() {
-    assert_all_eq!(5,4+1,3+2);
-    assert_all_eq!(5usize.pow(2),25,6*6-11,20+5);
-    assert_all_eq!(5*5,4*4+9);
+    assert_all_eq!(5, 4 + 1, 3 + 2);
+    assert_all_eq!(5usize.pow(2), 25, 6 * 6 - 11, 20 + 5);
+    assert_all_eq!(5 * 5, 4 * 4 + 9);
 }
 
 #[test]
 #[should_panic]
 fn test_assert_all_eq_failure_case1() {
-    assert_all_eq!(5,4+1,3+3);
+    assert_all_eq!(5, 4 + 1, 3 + 3);
 }
 
 #[test]
 #[should_panic]
 fn test_assert_all_eq_failure_case2() {
-    assert_all_eq!(5usize.pow(2),25,6*6-10,20+5);
+    assert_all_eq!(5usize.pow(2), 25, 6 * 6 - 10, 20 + 5);
 }

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -1,0 +1,36 @@
+/// A helper macro to assert that two or more expressions are the same.
+/// This is just easier than writing multiple assert_eq! to the same effect.
+/// But it has the drawback of not being able to pass additional error messages
+///
+/// ```
+/// assert_all_eq!(expression1, expression2, expression3,...)
+/// ``
+/// CAUTION: this does not have an additional info text
+macro_rules! assert_all_eq {
+    ($lhs:expr, $($expressions:expr),+) => {
+        $(
+            ::std::assert_eq!($lhs,$expressions);
+        )+
+    };
+
+
+}
+
+#[test]
+fn test_assert_all_eq_success_cases() {
+    assert_all_eq!(5,4+1,3+2);
+    assert_all_eq!(5usize.pow(2),25,6*6-11,20+5);
+    assert_all_eq!(5*5,4*4+9);
+}
+
+#[test]
+#[should_panic]
+fn test_assert_all_eq_failure_case1() {
+    assert_all_eq!(5,4+1,3+3);
+}
+
+#[test]
+#[should_panic]
+fn test_assert_all_eq_failure_case2() {
+    assert_all_eq!(5usize.pow(2),25,6*6-10,20+5);
+}

--- a/src/tests/macro_expansion.rs
+++ b/src/tests/macro_expansion.rs
@@ -16,7 +16,6 @@ fn any_of_macro_with_map_expansion_is_same_as_approved_expansion() {
     macrotest::expand("macro_expansion_tests/any_of_with_map_or_satisfies_expansion.rs");
 }
 
-
 #[test]
 /// test that the macro expansion is the same as a manually approved expansion test file
 fn all_of_macro_expansion_is_same_as_approved_expansion() {

--- a/src/tests/macro_expansion.rs
+++ b/src/tests/macro_expansion.rs
@@ -10,6 +10,15 @@ fn any_of_macro_expansion_is_same_as_approved_expansion() {
 
 #[test]
 /// test that the macro expansion is the same as a manually approved expansion test file
+fn any_of_macro_with_map_expansion_is_same_as_approved_expansion() {
+    // to update: delete the .expansion.rs file
+    // and replace macrotest::expand_without_refresh with macrotest::expand
+    macrotest::expand("macro_expansion_tests/any_of_with_map_or_satisfies_expansion.rs");
+}
+
+
+#[test]
+/// test that the macro expansion is the same as a manually approved expansion test file
 fn all_of_macro_expansion_is_same_as_approved_expansion() {
     // to update: delete the .expansion.rs file
     // and replace macrotest::expand_without_refresh with macrotest::expand

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,7 +3,7 @@ pub mod helper;
 
 mod all_of;
 mod any_of;
+mod any_of_with_map;
 mod macro_expansion;
 mod none_of;
 mod theorems;
-mod any_of_with_map;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+pub mod helper;
+
 mod all_of;
 mod any_of;
 mod macro_expansion;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,3 +3,4 @@ mod any_of;
 mod macro_expansion;
 mod none_of;
 mod theorems;
+mod any_of_with_map;


### PR DESCRIPTION
Add a syntax to transform (via `map`) the set in the `all_of` macro and apply a predicate to the whole set (via `satisfy`).